### PR TITLE
Add rotating cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,15 @@
 <body>
 <div class="text-container">
   Aaron Koshy
-  <div class="placeholder">Placeholder content coming soon...</div>
+  <div class="card-carousel">
+    <div class="carousel-inner">
+      <div class="card" style="--i:0">One</div>
+      <div class="card" style="--i:1">Two</div>
+      <div class="card" style="--i:2">Three</div>
+      <div class="card" style="--i:3">Four</div>
+      <div class="card" style="--i:4">Five</div>
+    </div>
+  </div>
 </div>
 <div class="scroll-content">
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel sapien non nunc maximus tempor. Aliquam erat volutpat.</p>

--- a/style.css
+++ b/style.css
@@ -19,8 +19,51 @@ html, body {
   text-shadow: 1px 1px rgba(0,0,0,0.1);
 }
 
-.placeholder {
-  font-size: 32px;
+
+.card-carousel {
+  margin-top: 20px;
+  width: 100vw;
+  height: 250px;
+  position: relative;
+  perspective: 1000px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.carousel-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  animation: rotateCarousel 20s linear infinite;
+  --n: 5;
+}
+
+.card {
+  position: absolute;
+  width: 180px;
+  height: 120px;
+  left: calc(50% - 90px);
+  top: 0;
+  background: rgba(255,255,255,0.9);
+  border-radius: 8px;
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  backface-visibility: hidden;
+  transform: rotateY(calc(var(--i) * 360deg / var(--n))) translateZ(360px);
+}
+
+@keyframes rotateCarousel {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(-360deg);
+  }
 }
 
 .scroll-content {


### PR DESCRIPTION
## Summary
- add rotating card carousel under the Aaron Koshy heading
- style cards with 3D rotation animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688823a41bcc83228f7794a6886f815f